### PR TITLE
Add new team members to the index

### DIFF
--- a/the-team/index.md
+++ b/the-team/index.md
@@ -27,6 +27,9 @@ The current team members are:
 * [Ganga Kafle @kafleg](https://profiles.wordpress.org/kafleg/)
 * [Evan Herman @eherman24](https://profiles.wordpress.org/eherman24/)
 * [Luke Carbis @lukecarbis](https://profiles.wordpress.org/lukecarbis/)
+* [Marcel Tannich @mardroid](https://profiles.wordpress.org/mardroid/)
+* [Shiva Shanker @shivashankerbhatta](https://profiles.wordpress.org/shivashankerbhatta/)
+* [Shameem Reza @shameemreza](https://profiles.wordpress.org/shameemreza/)
 
 ## Communication
 


### PR DESCRIPTION
I've added new members that they finished their onboarding to Plugins Team.

* [Marcel Tannich @mardroid](https://profiles.wordpress.org/mardroid/)
* [Shiva Shanker @shivashankerbhatta](https://profiles.wordpress.org/shivashankerbhatta/)
* [Shameem Reza @shameemreza](https://profiles.wordpress.org/shameemreza/)